### PR TITLE
requirements.txtにmatplotlibを明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 * [word_cloud](https://github.com/amueller/word_cloud)
 * [TinyDB](https://github.com/msiemens/tinydb)
 * [Flask](http://flask.pocoo.org/)
+* [Matplotlib](https://matplotlib.org/)
 
 ## やりたい
 * 画像生成でタイムアウトになりがちなのでAjaxとかでなんとかする

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mecab-python3==0.7
 wordcloud==1.5.0
 tinydb==3.11.0
 flask==1.0.2
+matplotlib==3.1.0


### PR DESCRIPTION
wordcloud1.5.0の依存関係から(何故か)matplotlibが外れてい、pipで自動的にインストールできない状態になっていたため追加しました。

