### PR TITLE
OAuth Scopesの指定範囲を狭く

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def register_app(host):
     data = {
         'client_name': 'TootCloud',
         'redirect_uris': app.config['SITE_URL'] + '/callback',
-        'scopes': 'read write',
+        'scopes': 'read:accounts read:statuses write:media write:statuses',
         'website': app.config['SITE_URL']
     }
     resp = requests.post("https://{host}/api/v1/apps".format(host=host), data=data)

--- a/templates/login2.html
+++ b/templates/login2.html
@@ -7,7 +7,7 @@
       {% if session['uri'] %}
       <p>下記のボタンから{{session['uri']}}にログインしてアプリを認証してください。</p>
       <div class="center">
-        <a class="button" href="https://{{session['uri']}}/oauth/authorize?client_id={{session['client_id']}}&response_type=code&redirect_uri={{site_url}}%2fcallback&scope=read%20write">ログイン</a>
+        <a class="button" href="https://{{session['uri']}}/oauth/authorize?client_id={{session['client_id']}}&response_type=code&redirect_uri={{site_url}}%2fcallback&scope=read:accounts%20read:statuses%20write:media%20write:statuses">ログイン</a>
       </div>
       {% else %}
       <p class="error">エラーが発生しました<a href="/login">こちら</a>からもう一度試してみてください。</p>


### PR DESCRIPTION
#15 
read writeの全権限を取っていたので`read:accounts read:statuses write:media write:statuses`に減らした

古いバージョンのmastodonでは解釈できないと思いますが、諦めましょう