### PR TITLE
デフォルトの除外リストと手動指定を併用できるように

### DIFF
--- a/main.py
+++ b/main.py
@@ -195,14 +195,13 @@ def result():
         if request.method == 'POST':
             num = int(request.form["TootsNum"])
             vis = request.form.getlist("visibility")
-            ex_opt = request.form.getlist("ExcludeWord")[0]
-            if ex_opt == "default":
+            ex_opt = len(request.form.getlist("defaultlist"))
+            if ex_opt == 1:
                 exl = swl
-            elif ex_opt == "specify":
-                ex = request.form["exlist"]
-                exl = re.split('\W+', ex)
             else:
                 exl = []
+            ex = request.form["exlist"]
+            exl.extend(re.split('\W+', ex))
             filename = wc(num, vis, exl)
             if filename == None:
                 return render_template('setting.html', status="logout", site_url=app.config['SITE_URL'], error="notext")

--- a/templates/setting.html
+++ b/templates/setting.html
@@ -18,10 +18,9 @@
           <label class="label-inline"><input type="checkbox" name="visibility" value="public" checked> 公開</label>
           <label class="label-inline"><input type="checkbox" name="visibility" value="unlisted"> 未収載</label>
           <label class="label-inline"><input type="checkbox" name="visibility" value="private"> 非公開</label>
-          <label for="ExcludeWord">除外ワード</label>
-          <label class="label-inline"><input type="radio" name="ExcludeWord" value="none"> なし</label>
-          <label class="label-inline"><input type="radio" name="ExcludeWord" value="default" checked> デフォルトの除外ワードを使う</label>
-          <label class="label-inline"><input type="radio" name="ExcludeWord" value="specify"> 以下で指定する（,で区切って複数指定）</label>
+          <label for="defaultlist">除外ワード</label>
+          <label class="label-inline"><input type="checkbox" name="defaultlist" value="true" checked> デフォルトの除外ワードを使う</label>
+          <label for="exlist">除外ワードを指定（,で区切って複数指定）</label>
           <textarea placeholder="これ,ない,…" id="ExcludeWord" name="exlist"></textarea>
           <input class="button-primary" type="submit" name="action" value="この設定でワードクラウドを作成！">
         </fieldset>


### PR DESCRIPTION
デフォルトの除外リストに含まれない単語を除外したい場合があるのでラジオボタンによる指定をやめ、手動で指定した除外リストとの併用可能にする。